### PR TITLE
Avoid deleting whole threads when ripping 1 page

### DIFF
--- a/taparip.pl
+++ b/taparip.pl
@@ -183,7 +183,8 @@ sub download_thread {
     my $schema = "$root_url :: $topic :: $start";
     my $dom = cache_get($schema);
 
-    $dbh->do('DELETE from posts where topic = ?', undef, $topic);
+    $dbh->do('DELETE from posts where topic = ? and seq between ? and
+ ?', undef, $topic, $start, $start + $posts_per_page - 1);
     if ($dbh->err) { die "Unable to delete $topic: $dbh-err : $dbh->errstr \n"; }
 
     if(! $dom) {


### PR DESCRIPTION
Hi,

While ripping a thread with more than 20 posts I found only the last messages are saved in the database.

The script downloads averything and the output confirms this, but in below example only the 5 messages with sequences 20 to 24 will be saved in the database:
```
Gathering data from https://www.tapatalk.com/groups/***/viewtopic.php
looking for thread t=1827&start=0 - downloaded - ***
10 saved
looking for thread t=1827&start=20 - downloaded - ***
5 saved
```

Reason is the `download_thread` function which is called recursively and deletes the whole thread every time, I modified it to delete only the posts from `$start` to `$start + $posts_per_page - 1`